### PR TITLE
Disable M1 build in Github Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,9 @@ jobs:
           python3 -m cibuildwheel --output-dir dist
         env:
           CIBW_ARCHS_LINUX: x86_64
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          # apple M1 image is not supported yet in Github Action: https://github.com/actions/runner-images/issues/2187
+          # We need to manually build this locally until this will be supported.
+          CIBW_ARCHS_MACOS: x86_64 # "x86_64 arm64"
           CIBW_BUILD: "cp37-*64 cp38-*64 cp39-*64 cp310-*64 cp311-*64"
           CIBW_BEFORE_BUILD_LINUX: bash scripts/install-manylinux-deps.sh
           CIBW_BEFORE_BUILD_MACOS: bash scripts/install-macos-deps.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ This file captures the main changes made to the pyvrs open source project since
 its creation. None of the changes made before pyvrs was open sourced are meant to
 be covered.
 
-# TODO update this before open source
-# Version 1.0 (December 16, 2021)
+# Version 1.0.4 (Mar 7, 2023)
 
 - Initial private release.


### PR DESCRIPTION
Summary:
It turns out that the M1 build is not working in Github Actions and will be supported in Q3 2023: https://github.com/actions/runner-images/issues/2187

Since this doesn't work right now, disable this build

Differential Revision: D43954575

