### PR TITLE
Add __str__ method for FileSpec

### DIFF
--- a/csrc/utils/PyFileSpec.cpp
+++ b/csrc/utils/PyFileSpec.cpp
@@ -34,7 +34,8 @@ void pybind_filespec(py::module& m) {
       .def("get_chunks", &PyFileSpec::getChunks)
       .def("get_chunk_sizes", &PyFileSpec::getChunkSizes)
       .def("get_filename", &PyFileSpec::getFileName)
-      .def("get_uri", &PyFileSpec::getUri);
+      .def("get_uri", &PyFileSpec::getUri)
+      .def("__str__", &PyFileSpec::toJson);
 }
 #endif
 } // namespace pyvrs

--- a/csrc/utils/PyFileSpec.h
+++ b/csrc/utils/PyFileSpec.h
@@ -69,6 +69,10 @@ class OssPyFileSpec {
     return spec_;
   }
 
+  const std::string toJson() const {
+    return spec_.toJson();
+  }
+
  protected:
   vrs::FileSpec spec_;
 };


### PR DESCRIPTION
Summary: Implement __str__ method for File Spec so that str(<file spec>) will print out meaningful information rather than Python object information (i.e. class and address).

Reviewed By: georges-berenger

Differential Revision: D45213810

