### PR TITLE
Use cibuildwheel v2.17.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,7 +52,7 @@ jobs:
           fi
           python -m pip install -U pip
           python -m pip install numpy typing dataclasses pytest parameterized Pillow
-          python -m pip install cibuildwheel
+          python -m pip install cibuildwheel==2.17.0
 
       - name: Build wheels for CPython
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel
+          python3 -m pip install cibuildwheel==2.17.0
 
       - name: Build wheels for CPython
         run: |

--- a/scripts/build-macos-arm64-package.sh
+++ b/scripts/build-macos-arm64-package.sh
@@ -51,7 +51,7 @@ export CIBW_BEFORE_BUILD_MACOS="arch -arm64 brew install boost cmake fmt glog jp
 export CIBW_SKIP="*-manylinux_i686 *musllinux*"
 
 # Build wheels for all specified versions
-python -m pip install cibuildwheel
+python -m pip install cibuildwheel==2.17.0
 python -m cibuildwheel --output-dir dist
 
 # # Upload to PyPI


### PR DESCRIPTION
Summary: We're seeing build breakages that are apparently caused by cibuildwheel v2.18, so let's keep using v2.17 for now.

Differential Revision:
D57464193

Privacy Context Container: L1181955


