### PR TITLE
Add missing explicit Jpeg dependency

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
             sudo apt-get upgrade -y
             sudo apt-get install -o Acquire::Retries=5 \
               cmake git ninja-build libgtest-dev libfmt-dev \
-              libturbojpeg-dev libpng-dev \
+              libjpeg-dev libturbojpeg-dev libpng-dev \
               liblz4-dev libzstd-dev libxxhash-dev \
               libboost-system-dev libboost-filesystem-dev libboost-thread-dev libboost-chrono-dev libboost-date-time-dev \
               portaudio19-dev

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,7 @@ build:
     - ccache
     - libgtest-dev
     - libfmt-dev
+    - libjpeg-dev
     - libturbojpeg-dev
     - libpng-dev
     - liblz4-dev


### PR DESCRIPTION
Summary: It appears an explicit jpeg dependency is missing sometimes, as shown by https://github.com/facebookresearch/pyvrs/actions/runs/12837232672/job/35800476535

Differential Revision: D68377914


