### PR TITLE
Fix bindings stubs generation

### DIFF
--- a/csrc/Pybind11.cpp
+++ b/csrc/Pybind11.cpp
@@ -26,6 +26,7 @@
 #if IS_VRS_FB_INTERNAL()
 #include "archive/Archive.h"
 #include "fb/FbInternal.h"
+#include "fb/dataset_snapshot/PyDatasetSnapshot.h"
 #include "filter/Filter.h" // Disable filter internally until AsyncImageFilter is reworked.
 #include "writer/Writer.h"
 #endif
@@ -45,15 +46,24 @@ PYBIND11_MODULE(PYBIND_MODULE_NAME, m) {
             :toctree: _generate
       )pbdoc";
 
+  // NOTE: the order of includes matters for FB-internal python stubs generation
+#if IS_VRS_FB_INTERNAL()
+  // Register some very basic types used in FB bindings
+  pyvrs::pybind_fbinternal_basics(m);
+#endif
+
   // Register submodules.
-  pyvrs::pybind_reader(m);
   pyvrs::pybind_utils(m);
 
+#if IS_VRS_FB_INTERNAL()
+  pyvrs::pybind_fbinternal(m);
+#endif
+  pyvrs::pybind_reader(m);
 #if IS_VRS_FB_INTERNAL()
   pyvrs::pybind_filter(m); // Disable filter internally until AsyncImageFilter is reworked.
   pyvrs::pybind_writer(m);
   pyvrs::pybind_archive(m);
-  pyvrs::pybind_fbinternal(m);
+  pyvrs::pybind_dataset_snapshot(m);
 #endif
 
 #ifdef VERSION_INFO

--- a/csrc/reader/Reader.cpp
+++ b/csrc/reader/Reader.cpp
@@ -17,17 +17,20 @@
 #include "Reader.h"
 
 #include <vrs/os/Platform.h>
+#include <vrs/utils/AudioTrackExtractor.h>
 
 #include "AsyncVRSReader.h"
+#include "FilteredFileReader.h"
 #include "MultiVRSReader.h"
 #include "VRSReader.h"
 
-#if IS_VRS_FB_INTERNAL()
-#include "FilteredFileReader.h"
-#endif
-
 namespace pyvrs {
 namespace py = pybind11;
+
+string extractAudioTrack(pyvrs::FilteredFileReader& filteredReader, const string& wavFilePath) {
+  initVrsBindings();
+  return vrs::utils::extractAudioTrack(filteredReader.getFilteredReader(), wavFilePath);
+}
 
 void pybind_reader(py::module& m) {
   py::enum_<pyvrs::ImageConversion>(m, "ImageConversion")
@@ -46,5 +49,10 @@ void pybind_reader(py::module& m) {
 #if IS_VRS_FB_INTERNAL()
   pybind_filtered_filereader(m);
 #endif
+
+  m.def(
+      "extract_audio_track",
+      &extractAudioTrack,
+      "Extract audio track from given FilteredFileReader");
 }
 } // namespace pyvrs

--- a/csrc/utils/PyBuffer.cpp
+++ b/csrc/utils/PyBuffer.cpp
@@ -595,22 +595,6 @@ void pybind_buffer(py::module& m) {
           .def("__str__", [](const PyContentBlock& block) { return block.asString(); });
   DEF_DICT_FUNC(contentBlock, PyContentBlock)
 
-  py::class_<pyvrs::ContentBlockBuffer>(m, "Buffer", py::buffer_protocol())
-      .def("jxl_compress", &pyvrs::ContentBlockBuffer::jxlCompress)
-      .def("jpg_compress", &pyvrs::ContentBlockBuffer::jpgCompress)
-      .def("decompress", &pyvrs::ContentBlockBuffer::decompress)
-      .def_buffer([](pyvrs::ContentBlockBuffer& block) -> py::buffer_info {
-        return pyvrs::convertContentBlockBuffer(block);
-      })
-      .def("__str__", [](const pyvrs::ContentBlockBuffer& block) {
-        return fmt::format(
-            "{}, {} bytes, structured: {}, adjusted: {}",
-            block.spec.asString(),
-            block.bytes.size(),
-            block.structuredArray,
-            block.bytesAdjusted);
-      });
-
   py::class_<pyvrs::ImageBuffer>(m, "ImageBuffer", py::buffer_protocol())
       .def(py::init<const PyImageContentBlockSpec&, const py::buffer&>())
       .def(py::init<const PyImageContentBlockSpec&, int64_t, const py::buffer&>())
@@ -630,6 +614,22 @@ void pybind_buffer(py::module& m) {
             image.spec.asString(),
             image.bytes.size(),
             image.recordIndex);
+      });
+
+  py::class_<pyvrs::ContentBlockBuffer>(m, "Buffer", py::buffer_protocol())
+      .def("jxl_compress", &pyvrs::ContentBlockBuffer::jxlCompress)
+      .def("jpg_compress", &pyvrs::ContentBlockBuffer::jpgCompress)
+      .def("decompress", &pyvrs::ContentBlockBuffer::decompress)
+      .def_buffer([](pyvrs::ContentBlockBuffer& block) -> py::buffer_info {
+        return pyvrs::convertContentBlockBuffer(block);
+      })
+      .def("__str__", [](const pyvrs::ContentBlockBuffer& block) {
+        return fmt::format(
+            "{}, {} bytes, structured: {}, adjusted: {}",
+            block.spec.asString(),
+            block.bytes.size(),
+            block.structuredArray,
+            block.bytesAdjusted);
       });
 
   py::class_<pyvrs::BinaryBuffer>(m, "BinaryBuffer", py::buffer_protocol())

--- a/csrc/utils/PyRecord.cpp
+++ b/csrc/utils/PyRecord.cpp
@@ -130,6 +130,34 @@ void pybind_record(py::module& m) {
 
   static_assert(int(vrs::PixelFormat::COUNT) == 23, "vrs::PixelFormat Python bindings incomplete");
 
+  py::enum_<vrs::AudioSampleFormat>(m, "AudioSampleFormat", py::arithmetic())
+      .value("UNDEFINED", vrs::AudioSampleFormat::UNDEFINED)
+      .value("S8", vrs::AudioSampleFormat::S8)
+      .value("U8", vrs::AudioSampleFormat::U8)
+      .value("A_LAW", vrs::AudioSampleFormat::A_LAW)
+      .value("MU_LAW", vrs::AudioSampleFormat::MU_LAW)
+      .value("S16_LE", vrs::AudioSampleFormat::S16_LE)
+      .value("U16_LE", vrs::AudioSampleFormat::U16_LE)
+      .value("S16_BE", vrs::AudioSampleFormat::S16_BE)
+      .value("U16_BE", vrs::AudioSampleFormat::U16_BE)
+      .value("S24_LE", vrs::AudioSampleFormat::S24_LE)
+      .value("U24_LE", vrs::AudioSampleFormat::U24_LE)
+      .value("S24_BE", vrs::AudioSampleFormat::S24_BE)
+      .value("U24_BE", vrs::AudioSampleFormat::U24_BE)
+      .value("S32_LE", vrs::AudioSampleFormat::S32_LE)
+      .value("U32_LE", vrs::AudioSampleFormat::U32_LE)
+      .value("S32_BE", vrs::AudioSampleFormat::S32_BE)
+      .value("U32_BE", vrs::AudioSampleFormat::U32_BE)
+      .value("F32_LE", vrs::AudioSampleFormat::F32_LE)
+      .value("F32_BE", vrs::AudioSampleFormat::F32_BE)
+      .value("F64_LE", vrs::AudioSampleFormat::F64_LE)
+      .value("F64_BE", vrs::AudioSampleFormat::F64_BE);
+
+  static_assert(
+      int(vrs::AudioSampleFormat::COUNT) == 21,
+      "vrs::AudioSampleFormat Python bindings incomplete");
+
+  py::enum_<vrs::RecordableTypeId>(m, "RecordableTypeId");
   py::class_<vrs::StreamId>(m, "RecordableId")
       .def("get_type_id", &vrs::StreamId::getTypeId)
       .def("get_instance_id", &vrs::StreamId::getInstanceId)
@@ -137,7 +165,6 @@ void pybind_record(py::module& m) {
       .def("get_type_name", &vrs::StreamId::getTypeName)
       .def("get_name", &vrs::StreamId::getName)
       .def("get_numeric_name", &vrs::StreamId::getNumericName);
-  py::enum_<vrs::RecordableTypeId>(m, "RecordableTypeId");
 
   m.def("recordable_type_id_name", [](const std::string& recordableIdAsString) {
     const vrs::StreamId recId = vrs::StreamId::fromNumericName(recordableIdAsString);

--- a/csrc/utils/Utils.cpp
+++ b/csrc/utils/Utils.cpp
@@ -17,11 +17,9 @@
 #include "Utils.h"
 
 #include <vrs/os/Platform.h>
-#include <vrs/utils/AudioTrackExtractor.h>
 #include <vrs/utils/Validation.h>
 
 #include "../VrsBindings.h"
-#include "../reader/FilteredFileReader.h"
 #include "PyBuffer.h"
 #include "PyExceptions.h"
 #include "PyFileSpec.h"
@@ -40,11 +38,6 @@ static string verbatimChecksum(const string& path, bool showProgress) {
   return vrs::utils::verbatimChecksum(path, showProgress);
 }
 
-string extractAudioTrack(pyvrs::FilteredFileReader& filteredReader, const string& wavFilePath) {
-  initVrsBindings();
-  return vrs::utils::extractAudioTrack(filteredReader.getFilteredReader(), wavFilePath);
-}
-
 void pybind_utils(py::module& m) {
   py::enum_<vrs::CompressionPreset>(m, "CompressionPreset")
       .value("NONE", vrs::CompressionPreset::None)
@@ -59,10 +52,6 @@ void pybind_utils(py::module& m) {
       .export_values();
   m.def("records_checksum", &recordsChecksum, "Calculate a VRS file's logical checksum");
   m.def("verbatim_checksum", &verbatimChecksum, "Calculate a file's checksum");
-  m.def(
-      "extract_audio_track",
-      &extractAudioTrack,
-      "Extract audio track from given FilteredFileReader");
   pybind_exception(m);
   pybind_record(m);
   pybind_buffer(m);

--- a/csrc/writer/Writer.cpp
+++ b/csrc/writer/Writer.cpp
@@ -73,23 +73,10 @@ using namespace vrs;
       }));
 
 void pybind_writer(py::module& m) {
-  py::class_<pyvrs::VRSWriter>(m, "Writer")
-      .def(py::init<>())
-      .def("resetNewInstanceIds", &pyvrs::VRSWriter::resetNewInstanceIds)
-      .def("create", py::overload_cast<const std::string&>(&pyvrs::VRSWriter::create))
-      .def("createStream", &pyvrs::VRSWriter::createStream, py::return_value_policy::reference)
-      .def(
-          "createFlavoredStream",
-          &pyvrs::VRSWriter::createFlavoredStream,
-          py::return_value_policy::reference)
-      .def("setTag", &pyvrs::VRSWriter::setTag)
-      .def("writeRecords", &pyvrs::VRSWriter::writeRecords)
-      .def("getBackgroundThreadQueueByteSize", &pyvrs::VRSWriter::getBackgroundThreadQueueByteSize)
-      .def("close", &pyvrs::VRSWriter::close)
-#if IS_VRS_FB_INTERNAL()
-#include "Writer_fb.hpp"
-#endif
-      ;
+  py::class_<pyvrs::PyRecordFormat, std::unique_ptr<pyvrs::PyRecordFormat, py::nodelete>>(
+      m, "RecordFormat")
+      .def("getMembers", &pyvrs::PyRecordFormat::getMembers)
+      .def("getJsonDataLayouts", &pyvrs::PyRecordFormat::getJsonDataLayouts);
 
   py::class_<pyvrs::PyStream, std::unique_ptr<pyvrs::PyStream, py::nodelete>>(m, "Stream")
       .def("createRecordFormat", &pyvrs::PyStream::createRecordFormat)
@@ -112,10 +99,23 @@ void pybind_writer(py::module& m) {
       .def("setTag", &pyvrs::PyStream::setTag)
       .def("getStreamID", &pyvrs::PyStream::getStreamID);
 
-  py::class_<pyvrs::PyRecordFormat, std::unique_ptr<pyvrs::PyRecordFormat, py::nodelete>>(
-      m, "RecordFormat")
-      .def("getMembers", &pyvrs::PyRecordFormat::getMembers)
-      .def("getJsonDataLayouts", &pyvrs::PyRecordFormat::getJsonDataLayouts);
+  py::class_<pyvrs::VRSWriter>(m, "Writer")
+      .def(py::init<>())
+      .def("resetNewInstanceIds", &pyvrs::VRSWriter::resetNewInstanceIds)
+      .def("create", py::overload_cast<const std::string&>(&pyvrs::VRSWriter::create))
+      .def("createStream", &pyvrs::VRSWriter::createStream, py::return_value_policy::reference)
+      .def(
+          "createFlavoredStream",
+          &pyvrs::VRSWriter::createFlavoredStream,
+          py::return_value_policy::reference)
+      .def("setTag", &pyvrs::VRSWriter::setTag)
+      .def("writeRecords", &pyvrs::VRSWriter::writeRecords)
+      .def("getBackgroundThreadQueueByteSize", &pyvrs::VRSWriter::getBackgroundThreadQueueByteSize)
+      .def("close", &pyvrs::VRSWriter::close)
+#if IS_VRS_FB_INTERNAL()
+#include "Writer_fb.hpp"
+#endif
+      ;
 
   py::class_<pyvrs::DataPieceWrapper>(m, "DataPieceWrapper").def(py::init<>());
 


### PR DESCRIPTION
Summary:
Regenerated bindings

```
buck run arvr/mode/platform010/opt //arvr/python/pyvrs2:vrsbindings_stubgen
```

This required a decent amount of work, because pybindings actually expect things to be declared in order of usage. In other words, you shouldn't declare a pybind for  `void do_something(MyType foo);` before the pybinding `MyType` itself. 

This makes sense, but in practice, the VRS pybindings were breaking these rules in a myriad of ways, so I had to move a lot of things around, and it was quite annoying to do so...

There is a way to prevent regression for this, I will reach out to VRS team about this...

Differential Revision: D69120247


