### PR TITLE
fix: Correct typo in Windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ python -m pip install -e .
 ### Windows (via pixi):
 
 ```
-# Donwload pyvrs
+# Download pyvrs
 git clone https://github.com/facebookresearch/pyvrs.git
 cd pyvrs
 git submodule sync --recursive


### PR DESCRIPTION
Changed "Donwload" to "Download" in the Windows installation section.