### PR TITLE
{Build} GitHub workflow - Do not upgrade

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,6 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
             sudo apt-get update -y
-            sudo apt-get upgrade -y
             sudo apt-get install -o Acquire::Retries=5 \
               cmake git ninja-build libgtest-dev libfmt-dev \
               libjpeg-dev libturbojpeg-dev libpng-dev \


### PR DESCRIPTION
Summary: As we are running update and install libraries later, we don't need to run upgrade (see D72653490 -- https://github.com/facebookresearch/vrs/commit/e516407ac3070e0c1de1456c9850b7fd8367216d)

Reviewed By: georges-berenger

Differential Revision: D75300290


