### PR TITLE
Expose setRelatedFileTags

### DIFF
--- a/csrc/reader/AsyncVRSReader.cpp
+++ b/csrc/reader/AsyncVRSReader.cpp
@@ -227,6 +227,7 @@ void pybind_asyncvrsreaders(py::module& m) {
       .def("open", py::overload_cast<const std::vector<std::string>&>(&PyAsyncMultiReader::open))
       .def("open", py::overload_cast<const std::vector<PyFileSpec>&>(&PyAsyncMultiReader::open))
       .def("close", &PyAsyncMultiReader::close)
+      .def("set_related_file_tags", &PyAsyncMultiReader::setRelatedFileTags)
       .def("set_encoding", &PyAsyncMultiReader::setEncoding)
       .def("get_encoding", &PyAsyncMultiReader::getEncoding)
       .def(

--- a/csrc/reader/MultiVRSReader.cpp
+++ b/csrc/reader/MultiVRSReader.cpp
@@ -170,6 +170,10 @@ int OssMultiVRSReader::close() {
   return reader_.close();
 }
 
+void OssMultiVRSReader::setRelatedFileTags(std::vector<std::string>&& tags) {
+  reader_.setRelatedFileTags(std::move(tags));
+}
+
 void OssMultiVRSReader::setEncoding(const string& encoding) {
   encoding_ = encoding;
 }
@@ -1018,6 +1022,7 @@ void pybind_multivrsreader(py::module& m) {
       .def("open", py::overload_cast<const std::vector<std::string>&>(&PyMultiVRSReader::open))
       .def("open", py::overload_cast<const std::vector<PyFileSpec>&>(&PyMultiVRSReader::open))
       .def("close", &PyMultiVRSReader::close)
+      .def("set_related_file_tags", &PyMultiVRSReader::setRelatedFileTags)
       .def("set_encoding", &PyMultiVRSReader::setEncoding)
       .def("get_encoding", &PyMultiVRSReader::getEncoding)
       .def(

--- a/csrc/reader/MultiVRSReader.h
+++ b/csrc/reader/MultiVRSReader.h
@@ -114,6 +114,9 @@ class OssMultiVRSReader : public VRSReaderBase {
 
   int close();
 
+  /// Set the tags that determine whether VRS files are related to each other.
+  void setRelatedFileTags(std::vector<std::string>&& tags);
+
   /// Set the character encoding to use when reading strings from the file.
   void setEncoding(const string& encoding);
 


### PR DESCRIPTION
Summary: The new MultiRecordFileReader::setRelatedFileTags() API allows the user to control which file tags are checked when opening mulitple VRS files together. This change merely makes the C++ API available in pyvrs.

Differential Revision: D80181779


