### PR TITLE
Fix macOS CI: set deployment target to 14.0, drop x86_64

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -63,7 +63,7 @@ jobs:
           CIBW_ARCHS_LINUX: x86_64
           # UPDATED: Changed to arm64 because macos-latest is now Apple Silicon
           CIBW_ARCHS_MACOS: "arm64"
-
+          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=14.0"
           CIBW_BUILD: "cp39-*64 cp310-*64 cp311-*64 cp312-*64"
           CIBW_BEFORE_BUILD_LINUX: bash scripts/install-manylinux-deps.sh
           CIBW_BEFORE_BUILD_MACOS: bash scripts/install-macos-deps.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,8 @@ jobs:
           python3 -m cibuildwheel --output-dir dist
         env:
           CIBW_ARCHS_LINUX: x86_64
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_MACOS: "arm64"
+          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=14.0"
           CIBW_BUILD: "cp39-*64 cp310-*64 cp311-*64 cp312-*64"
           CIBW_BEFORE_BUILD_LINUX: bash scripts/install-manylinux-deps.sh
           CIBW_BEFORE_BUILD_MACOS: bash scripts/install-macos-deps.sh


### PR DESCRIPTION
Summary:
The pyvrs GitHub Actions CI started failing on macOS because
cibuildwheel defaults MACOSX_DEPLOYMENT_TARGET to 10.9 for x86_64
builds, but VRS uses std::filesystem::path which requires macOS 10.15+.
The error: `'path' is unavailable: introduced in macOS 10.15`.

- Set MACOSX_DEPLOYMENT_TARGET=14.0 via CIBW_ENVIRONMENT_MACOS in both
  build-and-test.yml and deploy.yml
- Drop x86_64 from CIBW_ARCHS_MACOS in deploy.yml (build-and-test.yml
  already only builds arm64) since Apple has ended x86_64 Mac support

Differential Revision: D98636054


